### PR TITLE
Move to contexts completely

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,6 @@
             [lein-pprint "1.1.1"]
             [lein-environ "1.0.2"]
             [lein-ancient "0.6.10"]
-            [lein-cloverage "1.0.7-SNAPSHOT"]])
+            [lein-cloverage "1.0.7-SNAPSHOT"]]
+  :cljfmt {:indents {let-flow [[:inner 0]]
+                     catch [[:inner 0]]}})

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -15,19 +15,12 @@
     (math/expt wait (count failures))))
 
 (defn ^:private up-to
-  "Returns a function that when evaluated will either
-
-  1) return a number to use to wait until retrying a function again. Or,
-  2) throw an exception because the maximum number of retries, `stop`, has
-  been reached.
-
-  This is intended to be used in conjunction with 1-arg combinators
-  that take a vector of failures."
   [stop retry?]
   (fn [failures]
     (if (< (count failures) stop)
       (retry? failures)
       (throw (last failures)))))
+  "Returns a strategy that allows up to n retries. "
 
 (defn ^:private retry
   "Retry a function multiple times, pausing for a number of seconds between

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -38,7 +38,6 @@
   (md/loop [ctx {:failures []}]
     (md/catch
      (f)
-     Exception
       (fn [e] (md/chain (update ctx :failures conj e) strategy md/recur)))))
 
 (defn retry-exp-backoff

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -14,12 +14,13 @@
       (mt/in delay-ms #(md/success-deferred ctx)))))
 
 (defn ^:private up-to
-  [stop retry?]
-  (fn [failures]
-    (if (< (count failures) stop)
-      (retry? failures)
-      (throw (last failures)))))
   "Returns a strategy that allows up to n retries. "
+  [stop]
+  (fn [d]
+    (md/let-flow [{:keys [failures] :as ctx} d]
+      (if (< (count failures) stop)
+        ctx
+        (throw (last failures))))))
 
 (defn ^:private retry
   "Retry a function multiple times, pausing for a number of seconds between

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -6,7 +6,7 @@
 
 (defn ^:private exponentially
   "Returns a strategy that causes an exponentially increasing wait before
-  retrying."
+  retrying. The base wait is measured in seconds."
   [wait]
   (fn [failures]
     (math/expt wait (count failures))))

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -38,7 +38,7 @@
   (md/loop [ctx {:failures []}]
     (md/catch
      (f)
-      (fn [e] (md/chain (update ctx :failures conj e) strategy md/recur)))))
+     (fn [e] (md/chain (update ctx :failures conj e) strategy md/recur)))))
 
 (defn retry-exp-backoff
   "Takes a function that returns a `manifold.deferred/deferred`. Retries that

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -8,8 +8,10 @@
   "Returns a strategy that causes an exponentially increasing wait before
   retrying. The base wait is measured in seconds."
   [wait]
-  (fn [failures]
-    (math/expt wait (count failures))))
+  (fn [d]
+    (md/let-flow [{:keys [failures] :as ctx} d
+                  delay-ms (* 1000 (math/expt wait (count failures)))]
+      (mt/in delay-ms #(md/success-deferred ctx)))))
 
 (defn ^:private up-to
   [stop retry?]

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -5,11 +5,8 @@
    [manifold.time :as mt]))
 
 (defn ^:private exponentially
-  "Returns a function that when evaluated will produce the initial wait
-  raised to the number of failures.
-
-  This is intended to be used in conjunction with 1-arg combinators that take a
-  vector of failures."
+  "Returns a strategy that causes an exponentially increasing wait before
+  retrying."
   [wait]
   (fn [failures]
     (math/expt wait (count failures))))

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -57,5 +57,4 @@
 
   Returns a deferred wrapping the results of `f`."
   [f p stop]
-  (retry f (->> (exponentially p)
-                (up-to stop))))
+  (retry f (comp (exponentially p) (up-to stop))))

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -38,7 +38,9 @@
   (md/loop [ctx {:failures []}]
     (md/catch
      (f)
-     (fn [e] (md/chain (update ctx :failures conj e) strategy md/recur)))))
+     (fn [e]
+       (let [ctx (update ctx :failures conj e)]
+         (md/chain (strategy ctx) md/recur))))))
 
 (defn retry-exp-backoff
   "Takes a function that returns a `manifold.deferred/deferred`. Retries that

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -10,7 +10,7 @@
   [wait]
   (fn [d]
     (md/let-flow [{:keys [failures] :as ctx} d
-                  delay-ms (* 1000 (math/expt wait (count failures)))]
+                  delay-ms (mt/seconds (math/expt wait (count failures)))]
       (mt/in delay-ms #(md/success-deferred ctx)))))
 
 (defn ^:private up-to

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -14,7 +14,8 @@
       (mt/in delay-ms #(md/success-deferred ctx)))))
 
 (defn ^:private up-to
-  "Returns a strategy that allows up to n retries. "
+  "Returns a strategy that allows up to `stop` retries, otherwise
+  raises the last exception."
   [stop]
   (fn [d]
     (md/let-flow [{:keys [failures] :as ctx} d]

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -24,12 +24,11 @@
   each try.
 
   f -  a function that should be retried; must return a deferred
-
-  strategy - a retry strategy, which takes a retry context and returns
-      a (potentially deferred) retry context or exception. If an exception
-      is raised, retrying stops and the exception is passed on to the
-      deferred returned by this fn. Otherwise, continues execution with
-      the given retry context.
+  strategy - a retry strategy, which takes a deferred retry context and
+      returns a deferred retry context, deferred with an exception, or a
+      synchronous exception. In the error case, retrying stops and the
+      exception is passed on to the deferred returned by this fn. Otherwise,
+      continues execution with the given retry context.
 
   Returns a deferred wrapping the results of `f`."
   [f strategy]

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -35,14 +35,11 @@
 
   Returns a deferred wrapping the results of `f`."
   [f strategy]
-  (md/loop [failures []]
+  (md/loop [ctx {:failures []}]
     (md/catch
      (f)
      Exception
-      (fn [exc]
-        (let [all-failures (conj failures exc)
-              wait (strategy all-failures)]
-          (mt/in (mt/seconds wait) #(md/recur all-failures)))))))
+      (fn [e] (md/chain (update ctx :failures conj e) strategy md/recur)))))
 
 (defn retry-exp-backoff
   "Takes a function that returns a `manifold.deferred/deferred`. Retries that

--- a/src/banach/retry.clj
+++ b/src/banach/retry.clj
@@ -21,8 +21,8 @@
   2) throw an exception because the maximum number of retries, `stop`, has
   been reached.
 
-  This is intended to be used in conjunction with 1-arg combinators that take a
-  vector of failures."
+  This is intended to be used in conjunction with 1-arg combinators
+  that take a vector of failures."
   [stop retry?]
   (fn [failures]
     (if (< (count failures) stop)

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -25,18 +25,15 @@
 
 (deftest up-to-tests
   (testing "raises most recent exception when number of tries exceeded"
-    (let [tries [(Exception. "earlier")
-                 (Exception. "recent")]
-          stop 2
-          retry? #(throw (Exception. "I shouldn't have been called"))
-          f (#'retry/up-to stop retry?)]
-      (is (thrown-with-msg? Exception #"recent" (f tries)))))
-  (testing "returns the result of retry when number of tries less than max"
-    (let [tries []
-          retry? (constantly :success)
-          stop 2
-          f (#'retry/up-to stop retry?)]
-      (is (= :success (f tries))))))
+    (let [ctx {:failuers [(Exception. "earlier") (Exception. "recent")]}
+          strategy (#'retry/up-to 2)]
+      (is (thrown-with-msg?
+           Exception #"recent"
+           @(strategy (md/success-deferred ctx))))))
+  (testing "returns the ctx when tries remaining"
+    (let [ctx {:failures []}
+          strategy (#'retry/up-to 2)]
+      (is (= ctx @(strategy ctx))))))
 
 (deftest retry-tests
   (testing "retry returns the result of f on success"

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -48,7 +48,7 @@
   (testing "retries calling f"
     (let [c (mt/mock-clock)
           attempts (atom 0)
-          strategy (fn [failures]
+          strategy (fn [{:keys [failures]}]
                      (swap! attempts inc)
                      ;; allow one failure, then explode
                      (if (= (count failures) 1)

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -37,8 +37,7 @@
 
 (deftest retry-tests
   (testing "retry returns the result of f on success"
-    (let [c (mt/mock-clock)
-          called (atom false)
+    (let [called (atom false)
           strategy (fn [ctx] (reset! called true) ctx)
           f #(md/success-deferred :finished)
           ret (#'retry/retry f strategy)]

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -39,7 +39,7 @@
   (testing "retry returns the result of f on success"
     (let [c (mt/mock-clock)
           called (atom false)
-          strategy (fn [_failures] (reset! called true))
+          strategy (fn [_ctx] (reset! called true) ctx)
           f #(md/success-deferred :finished)
           ret (#'retry/retry f strategy)]
       ;; no clock necessary, time won't be a factor in test.

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -12,7 +12,7 @@
           delay-is (fn [delay failures]
                      (let [ctx {:failures failures}
                            d (strategy (md/success-deferred ctx))
-                           delay-ms (* 1000 delay)]
+                           delay-ms (mt/seconds delay)]
                        (is (not (md/realized? d)))
                        (mt/advance c (dec delay-ms))
                        (is (not (md/realized? d)))

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -39,7 +39,7 @@
   (testing "retry returns the result of f on success"
     (let [c (mt/mock-clock)
           called (atom false)
-          strategy (fn [_ctx] (reset! called true) ctx)
+          strategy (fn [ctx] (reset! called true) ctx)
           f #(md/success-deferred :finished)
           ret (#'retry/retry f strategy)]
       ;; no clock necessary, time won't be a factor in test.

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -41,7 +41,6 @@
           strategy (fn [ctx] (reset! called true) ctx)
           f #(md/success-deferred :finished)
           ret (#'retry/retry f strategy)]
-      ;; no clock necessary, time won't be a factor in test.
       (is (not @called))
       (is (= :finished @ret))))
   (testing "retries calling f"

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -25,7 +25,7 @@
 
 (deftest up-to-tests
   (testing "raises most recent exception when number of tries exceeded"
-    (let [ctx {:failuers [(Exception. "earlier") (Exception. "recent")]}
+    (let [ctx {:failures [(Exception. "earlier") (Exception. "recent")]}
           strategy (#'retry/up-to 2)]
       (is (thrown-with-msg?
            Exception #"recent"

--- a/test/banach/retry_test.clj
+++ b/test/banach/retry_test.clj
@@ -6,7 +6,7 @@
             [banach.retry :as retry]))
 
 (deftest exponentially-tests
-  (testing "returns a function that will raise the wait period to the number of failures"
+  (testing "wait exponentially as failure count increases"
     (let [c (mt/mock-clock)
           f (#'retry/exponentially 10)
           delay-is (fn [delay x] (is (= delay x)))]


### PR DESCRIPTION
This makes strategies composable (as in `comp`) and makes them return deferred contexts. This paves the way for strategies storing state in that extensible map.
